### PR TITLE
[fix] set COMPOSER_HOME before building plugins

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -139,6 +139,9 @@ admin_mail=$(ynh_user_get_info $admin 'mail')
 #=================================================
 ynh_print_info --message="Building plugins..."
 
+mkdir -p "$final_path/include/plugins/build/.config/composer"
+export COMPOSER_HOME="$final_path/include/plugins/build/.config/composer"
+
 pushd "$final_path/include/plugins/build"
 	php make.php hydrate
 	php -dphar.readonly=0 make.php build auth-cas

--- a/scripts/install
+++ b/scripts/install
@@ -140,7 +140,7 @@ admin_mail=$(ynh_user_get_info $admin 'mail')
 ynh_print_info --message="Building plugins..."
 
 mkdir -p "$final_path/include/plugins/build/.config/composer"
-export COMPOSER_HOME="$final_path/include/plugins/build/.config/composer"
+COMPOSER_HOME="$final_path/include/plugins/build/.config/composer"
 
 pushd "$final_path/include/plugins/build"
 	php make.php hydrate

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -151,7 +151,7 @@ ynh_print_info --message="Building plugins..."
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	mkdir -p "$final_path/include/plugins/build/.config/composer"
-	export COMPOSER_HOME="$final_path/include/plugins/build/.config/composer"
+	COMPOSER_HOME="$final_path/include/plugins/build/.config/composer"
 	pushd "$final_path/include/plugins/build"
 		php make.php hydrate
 		php -dphar.readonly=0 make.php build auth-cas

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,14 +82,14 @@ ynh_abort_if_errors
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_print_info --message="Upgrading source files..."
-	
+
 	tmpdir="$(mktemp -d)"
 
 	mkdir $tmpdir/plugins
 	rsync -a "$final_path/include/plugins" "$tmpdir/."
 	rsync -a "$config_file" "$tmpdir/."
 	ynh_secure_remove --file="$final_path"
-	
+
 	# Download, check integrity, uncompress and patch the source from app.src
 	ynh_setup_source --dest_dir="$final_path"
 	ynh_setup_source --dest_dir="$final_path/include/plugins/build" --source_id="core-plugins"
@@ -150,6 +150,8 @@ ynh_print_info --message="Building plugins..."
 
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
+	mkdir -p "$final_path/include/plugins/build/.config/composer"
+	export COMPOSER_HOME="$final_path/include/plugins/build/.config/composer"
 	pushd "$final_path/include/plugins/build"
 		php make.php hydrate
 		php -dphar.readonly=0 make.php build auth-cas


### PR DESCRIPTION
## Problem
- See #7.

## Solution
- `make.php` needs Composer which is not really initialized properly, and lacks a `COMPOSER_HOME`
- ~~I am not sure an `export COMPOSER_HOME` is a clean solution, but eh, it works.~~

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/osticket_ynh%20(tituspijean)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/osticket_ynh%20(tituspijean)/)  
