### PR TITLE
Update nginx.conf

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,11 +9,7 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   client_max_body_size 256M;
 
-  try_files $uri $uri/ index.php;
-  
-  location ~ ^/api/(?!http.php/)(.*) {
-     try_files $uri $uri/ /api/http.php/$1;
-  }
+  try_files $uri $uri/ index.php
   
   location ~ ^/pages/(?!index.php/)(.*) {
       try_files $uri $uri/ /pages/index.php/$1;
@@ -32,6 +28,10 @@ location __PATH__/ {
 
   # Include SSOWAT user panel.
   include conf.d/yunohost_panel.conf.inc;
+}
+
+location ~ ^/api/(?!http.php/)(.*) {
+  try_files $uri $uri/ /api/http.php/$1;
 }
 
 location /include {


### PR DESCRIPTION
Move ^/api location stanza out of root location

## Problem

- *Description of why you made this PR*
The osTicket API URL returned a 404 error when making a request.  The Nginx error log showed this: `"/usr/share/nginx/htmlapi/http.php/tickets.json" failed (2: No such file or directory)`

## Solution

- *And how do you fix that problem*

Move the ^/api location stanza below the root location stanza

Tested by making a request with Postman

## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [x ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
